### PR TITLE
Update README/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Refactor modules for [nvim-treesitter](https://github.com/nvim-treesitter/nvim-t
 
 ## Installation
 
-You can install `nvim-treesitter` with your favorite package manager, or using the default `pack` feature of Neovim!
+You can install `nvim-treesitter-refactor` with your favorite package manager,
+or using the default `pack` feature of Neovim!
+
+Note: This plugin requires [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) installed.
 
 ### Using a package manager
 
@@ -14,7 +17,7 @@ If you are using [vim-plug](https://github.com/junegunn/vim-plug), put this in y
 Plug 'nvim-treesitter/nvim-treesitter-refactor'
 ```
 
-## Refactor: highlight definitions
+## Highlight definitions
 
 Highlights definition and usages of the current symbol under the cursor.
 
@@ -28,7 +31,7 @@ require'nvim-treesitter.configs'.setup {
 EOF
 ```
 
-## Refactor: highlight current scope
+## Highlight current scope
 
 Highlights the block from the current scope where the cursor is.
 
@@ -42,7 +45,7 @@ require'nvim-treesitter.configs'.setup {
 EOF
 ```
 
-## Refactor: smart rename
+## Smart rename
 
 Renames the symbol under the cursor within the current scope (and current file).
 
@@ -61,7 +64,7 @@ require'nvim-treesitter.configs'.setup {
 EOF
 ```
 
-## Refactor: navigation
+## Navigation
 
 Provides "go to definition" for the symbol under the cursor,
 and lists the definitions from the current file. If you use

--- a/doc/nvim-treesitter-refactor.txt
+++ b/doc/nvim-treesitter-refactor.txt
@@ -1,23 +1,23 @@
-*nvim-treesitter-refactor*
+*nvim-treesitter-refactor.txt*
 
 Minimum version of neovim: nightly
 
 Authors: Steven Sojka <steelsojka@gmail.com>
          Yazdani Kiyan <yazdani.kiyan@protonmail.com>
          Vigouroux Thomas <tomvig38@gmail.com>
-         https://github.com/nvim-treesitter/nvim-treesitter/graphs/contributors
+         https://github.com/nvim-treesitter/nvim-treesitter-refactor/graphs/contributors
 
                                        Type |gO| to see the table of contents.
 
 ==============================================================================
-QUICK START                                       *nvim-treesitter-quickstart*
+QUICK START                                         *nvim-treesitter-refactor*
 
-See :help nvim-treesitter on how to configure modules
+See |nvim-treesitter-modules| on how to configure modules.
 
 ------------------------------------------------------------------------------
-REFACTOR                                        *nvim-treesitter-refactor-mod*
+MODULES                                     *nvim-treesitter-refactor-modules*
 
-                                *nvim-treesitter-highlight-definitions-submod*
+			      *nvim-treesitter-refactor-highlight-definitions*
 Highlight definitions~
 
 Highlights definition and usages of the current symbol under the cursor.
@@ -37,7 +37,7 @@ Supported options:
   EOF
 <
 
-                              *nvim-treesitter-highlight-current-scope-submod*
+			    *nvim-treesitter-refactor-highlight-current-scope*
 Highlight current scope~
 
 Highlights the block from the current scope where the cursor is.
@@ -57,7 +57,7 @@ Supported options:
   EOF
 <
 
-                                         *nvim-treesitter-smart-rename-submod*
+				       *nvim-treesitter-refactor-smart-rename*
 Smart rename~
 
 Renames the symbol under the cursor within the current scope (and current file).
@@ -85,7 +85,7 @@ Supported options:
   EOF
 <
 
-                                           *nvim-treesitter-navigation-submod*
+					 *nvim-treesitter-refactor-navigation*
 Navigation~
 
 Provides "go to definition" for the symbol under the cursor,
@@ -133,24 +133,21 @@ Supported options:
 <
 
 ==============================================================================
-MODULE-HIGHLIGHTS                          *nvim-treesitter-module-highlights*
-
-Apart from the general purpose highlights in |nvim-treesitter-highlights|,
-some submodules use their own highlight groups to visualize additional
-information.
+HIGHLIGHTS                               *nvim-treesitter-refactor-highlights*
 
 `TSDefinition`
                                                               *hl-TSDefinition*
-Used by refactor.highlight_definitions to highlight the definition of the
-symbol under the cursor.
+Used by |nvim-treesitter-refactor-highlight-definitions| to highlight the
+definition of the symbol under the cursor.
 
 `TSDefinitionUsage`
                                                          *hl-TSDefinitionUsage*
-Used by refactor.highlight_definitions to highlight usages of the symbol under
-the cursor.
+Used by |nvim-treesitter-refactor-highlight-definitions| to highlight usages
+of the symbol under the cursor.
 
 `TSCurrentScope`
                                                             *hl-TSCurrentScope*
-Used by refactor.highlight_current_scope to highlight the current scope.
+Used by |nvim-treesitter-refactor-highlight-current-scope| to highlight the
+current scope.
 
 vim:tw=78:ts=8:expandtab:noet:ft=help:norl:


### PR DESCRIPTION
Drop the "refactor" prefix for some titles. Set the nvim-treesitter-refactor for help tags. Thoughts on using `nvim-ts-refactor-`? for help tags? It's getting long p: