### PR TITLE
Remove duplicated help tag in quickstart section

### DIFF
--- a/doc/nvim-treesitter-refactor.txt
+++ b/doc/nvim-treesitter-refactor.txt
@@ -10,7 +10,7 @@ Authors: Steven Sojka <steelsojka@gmail.com>
                                        Type |gO| to see the table of contents.
 
 ==============================================================================
-QUICK START                                       *nvim-treesitter-quickstart*
+QUICK START                              *nvim-treesitter-refactor-quickstart*
 
 See :help nvim-treesitter on how to configure modules
 


### PR DESCRIPTION
The used tag equals the one used in the `nvim-treesitter` plugin. Thereby the help tag generation fails as this plugins depends on the queries of the referenced plugin.

[Here](https://github.com/nvim-treesitter/nvim-treesitter/blob/289cdc9da8f7f21dcbf814032e9277ef0e9790a0/doc/nvim-treesitter.txt#L19) the "original" help tag.
Alternatively we could also remove the whole quickstart section here as the `nvim-treesitter-text-objects` plugin does. :shrug: 