### PR TITLE
Fix `goto_definition_lsp_fallback`

### DIFF
--- a/lua/nvim-treesitter-refactor/navigation.lua
+++ b/lua/nvim-treesitter-refactor/navigation.lua
@@ -16,7 +16,7 @@ function M.goto_definition(bufnr, fallback_function)
 
   local definition = locals.find_definition(node_at_point, bufnr)
 
-  if fallback_function and definition.id == node_at_point.id then
+  if fallback_function and definition == node_at_point then
     fallback_function()
   else
     ts_utils.goto_node(definition)


### PR DESCRIPTION
Tested this locally and comparing `id` returns true, comparing the node itself gives the expected result (true when they are the same and false when they are different).

Ref https://github.com/nvim-treesitter/nvim-treesitter-refactor/issues/18#issuecomment-823457754