### PR TITLE
adapt to vim.treesitter.query.get_node_text

### DIFF
--- a/lua/nvim-treesitter-refactor/navigation.lua
+++ b/lua/nvim-treesitter-refactor/navigation.lua
@@ -71,7 +71,7 @@ function M.list_definitions(bufnr)
   for _, node in ipairs(definitions) do
     local lnum, col, _ = node.node:start()
     local type = string.upper(node.type:sub(1, 1))
-    local text = ts_query.get_node_text(node.node) or ""
+    local text = ts_query.get_node_text(node.node, bufnr) or ""
     table.insert(qf_list, {
       bufnr = bufnr,
       lnum = lnum + 1,
@@ -126,7 +126,7 @@ function M.list_definitions_toc()
 
     local lnum, col, _ = def.node:start()
     local type = string.upper(def.type:sub(1, 1))
-    local text = ts_query.get_node_text(def.node) or ""
+    local text = ts_query.get_node_text(def.node, bufnr) or ""
     table.insert(loc_list, {
       bufnr = bufnr,
       lnum = lnum + 1,

--- a/lua/nvim-treesitter-refactor/navigation.lua
+++ b/lua/nvim-treesitter-refactor/navigation.lua
@@ -4,6 +4,7 @@ local ts_utils = require "nvim-treesitter.ts_utils"
 local utils = require "nvim-treesitter.utils"
 local locals = require "nvim-treesitter.locals"
 local configs = require "nvim-treesitter.configs"
+local ts_query = vim.treesitter.query
 local api = vim.api
 
 local M = {}
@@ -70,7 +71,7 @@ function M.list_definitions(bufnr)
   for _, node in ipairs(definitions) do
     local lnum, col, _ = node.node:start()
     local type = string.upper(node.type:sub(1, 1))
-    local text = ts_utils.get_node_text(node.node)[1] or ""
+    local text = ts_query.get_node_text(node.node) or ""
     table.insert(qf_list, {
       bufnr = bufnr,
       lnum = lnum + 1,
@@ -125,7 +126,7 @@ function M.list_definitions_toc()
 
     local lnum, col, _ = def.node:start()
     local type = string.upper(def.type:sub(1, 1))
-    local text = ts_utils.get_node_text(def.node)[1] or ""
+    local text = ts_query.get_node_text(def.node) or ""
     table.insert(loc_list, {
       bufnr = bufnr,
       lnum = lnum + 1,

--- a/lua/nvim-treesitter-refactor/smart_rename.lua
+++ b/lua/nvim-treesitter-refactor/smart_rename.lua
@@ -5,6 +5,7 @@ local ts_utils = require "nvim-treesitter.ts_utils"
 local locals = require "nvim-treesitter.locals"
 local configs = require "nvim-treesitter.configs"
 local utils = require "nvim-treesitter.utils"
+local ts_query = vim.treesitter.query
 local api = vim.api
 
 local M = {}
@@ -42,7 +43,7 @@ function M.smart_rename(bufnr)
     return
   end
 
-  local node_text = ts_utils.get_node_text(node_at_point)[1]
+  local node_text = ts_query.get_node_text(node_at_point)
   local input = { prompt = "New name: ", default = node_text or "" }
   if not vim.ui.input then
     local new_name = vim.fn.input(input.prompt, input.default)

--- a/lua/nvim-treesitter-refactor/smart_rename.lua
+++ b/lua/nvim-treesitter-refactor/smart_rename.lua
@@ -43,7 +43,7 @@ function M.smart_rename(bufnr)
     return
   end
 
-  local node_text = ts_query.get_node_text(node_at_point)
+  local node_text = ts_query.get_node_text(node_at_point, bufnr)
   local input = { prompt = "New name: ", default = node_text or "" }
   if not vim.ui.input then
     local new_name = vim.fn.input(input.prompt, input.default)


### PR DESCRIPTION
vim.treesitter.query.get_node_text returns a string, not a table as the deprecated function.
