### PR TITLE
Support disabling mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ require'nvim-treesitter.configs'.setup {
   refactor = {
     smart_rename = {
       enable = true,
+      -- Assign keymaps to false to disable them, e.g. `smart_rename = false`.
       keymaps = {
         smart_rename = "grr",
       },
@@ -83,6 +84,7 @@ require'nvim-treesitter.configs'.setup {
   refactor = {
     navigation = {
       enable = true,
+      -- Assign keymaps to false to disable them, e.g. `goto_definition = false`.
       keymaps = {
         goto_definition = "gnd",
         list_definitions = "gnD",

--- a/doc/nvim-treesitter-refactor.txt
+++ b/doc/nvim-treesitter-refactor.txt
@@ -83,6 +83,7 @@ Supported options:
     refactor = {
       smart_rename = {
         enable = true,
+        -- Assign keymaps to false to disable them, e.g. `smart_rename = false`.
         keymaps = {
           smart_rename = "grr",
         },
@@ -126,6 +127,7 @@ Supported options:
     refactor = {
       navigation = {
         enable = true,
+        -- Assign keymaps to false to disable them, e.g. `goto_definition = false`.
         keymaps = {
           goto_definition = "gnd",
           list_definitions = "gnD",

--- a/lua/nvim-treesitter-refactor/navigation.lua
+++ b/lua/nvim-treesitter-refactor/navigation.lua
@@ -173,9 +173,10 @@ function M.attach(bufnr)
   local config = configs.get_module "refactor.navigation"
 
   for fn_name, mapping in pairs(config.keymaps) do
-    local cmd = string.format([[:lua require'nvim-treesitter-refactor.navigation'.%s(%d)<CR>]], fn_name, bufnr)
-
-    api.nvim_buf_set_keymap(bufnr, "n", mapping, cmd, { silent = true, noremap = true, desc = fn_name })
+    if mapping then
+      local cmd = string.format([[:lua require'nvim-treesitter-refactor.navigation'.%s(%d)<CR>]], fn_name, bufnr)
+      api.nvim_buf_set_keymap(bufnr, "n", mapping, cmd, { silent = true, noremap = true, desc = fn_name })
+    end
   end
 end
 
@@ -183,7 +184,9 @@ function M.detach(bufnr)
   local config = configs.get_module "refactor.navigation"
 
   for _, mapping in pairs(config.keymaps) do
-    api.nvim_buf_del_keymap(bufnr, "n", mapping)
+    if mapping then
+      api.nvim_buf_del_keymap(bufnr, "n", mapping)
+    end
   end
 end
 

--- a/lua/nvim-treesitter-refactor/smart_rename.lua
+++ b/lua/nvim-treesitter-refactor/smart_rename.lua
@@ -57,8 +57,10 @@ function M.attach(bufnr)
   local config = configs.get_module "refactor.smart_rename"
 
   for fn_name, mapping in pairs(config.keymaps) do
-    local cmd = string.format([[:lua require'nvim-treesitter-refactor.smart_rename'.%s(%d)<CR>]], fn_name, bufnr)
-    api.nvim_buf_set_keymap(bufnr, "n", mapping, cmd, { silent = true, noremap = true, desc = fn_name })
+    if mapping then
+      local cmd = string.format([[:lua require'nvim-treesitter-refactor.smart_rename'.%s(%d)<CR>]], fn_name, bufnr)
+      api.nvim_buf_set_keymap(bufnr, "n", mapping, cmd, { silent = true, noremap = true, desc = fn_name })
+    end
   end
 end
 
@@ -66,7 +68,9 @@ function M.detach(bufnr)
   local config = configs.get_module "refactor.smart_rename"
 
   for _, mapping in pairs(config.keymaps) do
-    api.nvim_buf_del_keymap(bufnr, "n", mapping)
+    if mapping then
+      api.nvim_buf_del_keymap(bufnr, "n", mapping)
+    end
   end
 end
 


### PR DESCRIPTION
Currently there is no way to disable default mappings. The best you can
do is use some unlikely key combinations on the left-hand side so that
defaults like `gnd` don't get used.

This change allows using `false` to disable mappings, which is a common
pattern in other Lua plugins.