### PR TITLE
made navigation.goto_{next,previous}_usage honor v:count

### DIFF
--- a/lua/nvim-treesitter-refactor/navigation.lua
+++ b/lua/nvim-treesitter-refactor/navigation.lua
@@ -163,14 +163,16 @@ function M.goto_adjacent_usage(bufnr, delta)
 end
 
 function M.goto_next_usage(bufnr)
-  return M.goto_adjacent_usage(bufnr, 1)
+  local delta = math.max(vim.v.count, 1)
+  M.goto_adjacent_usage(bufnr, delta)
 end
 function M.goto_previous_usage(bufnr)
-  return M.goto_adjacent_usage(bufnr, -1)
+  local delta = math.max(vim.v.count, 1)
+  M.goto_adjacent_usage(bufnr, -delta)
 end
 
 function M.attach(bufnr)
-  local config = configs.get_module "refactor.navigation"
+  local config = configs.get_module("refactor.navigation")
 
   for fn_name, mapping in pairs(config.keymaps) do
     local cmd = string.format([[:lua require'nvim-treesitter-refactor.navigation'.%s(%d)<CR>]], fn_name, bufnr)


### PR DESCRIPTION
this pr enables user navigate to next/previous n usage site, eg. `5[u`, `3]u`.
(assuming `[u` bound to navigation.goto_next_usage, and the opposite for `]u`)

btw, i dont see the fit of this feature in other modules