### PR TITLE
fix: vendor removed function `index_of`

### DIFF
--- a/lua/nvim-treesitter-refactor/navigation.lua
+++ b/lua/nvim-treesitter-refactor/navigation.lua
@@ -1,13 +1,20 @@
 -- Definition based navigation module
 
 local ts_utils = require "nvim-treesitter.ts_utils"
-local utils = require "nvim-treesitter.utils"
 local locals = require "nvim-treesitter.locals"
 local configs = require "nvim-treesitter.configs"
 local ts_query = vim.treesitter.query
 local api = vim.api
 
 local M = {}
+
+local function index_of(tbl, obj)
+  for i, o in ipairs(tbl) do
+    if o == obj then
+      return i
+    end
+  end
+end
 
 function M.goto_definition(bufnr, fallback_function)
   local bufnr = bufnr or api.nvim_get_current_buf()
@@ -153,7 +160,7 @@ function M.goto_adjacent_usage(bufnr, delta)
   local def_node, scope = locals.find_definition(node_at_point, bufnr)
   local usages = locals.find_usages(def_node, scope, bufnr)
 
-  local index = utils.index_of(usages, node_at_point)
+  local index = index_of(usages, node_at_point)
   if not index then
     return
   end


### PR DESCRIPTION
`utils.index_of` was removed in
https://github.com/nvim-treesitter/nvim-treesitter/commit/853b1ab39ae80b2e0e4a2224ac49f1763f025385#diff-80e9d2073d6762e6b809df6f9b2da04be7f0d87384ccd3abe8c723d88b1be3e6

Fixes #46