### PR TITLE
fix double-application of highlight to definition node

### DIFF
--- a/lua/nvim-treesitter-refactor/highlight_definitions.lua
+++ b/lua/nvim-treesitter-refactor/highlight_definitions.lua
@@ -30,7 +30,7 @@ function M.highlight_usages(bufnr)
   local usages = locals.find_usages(def_node, scope, bufnr)
 
   for _, usage_node in ipairs(usages) do
-    if usage_node ~= node_at_point then
+    if usage_node ~= node_at_point and usage_node ~= def_node then
       ts_utils.highlight_node(usage_node, bufnr, usage_namespace, "TSDefinitionUsage")
     end
   end


### PR DESCRIPTION
In some colorschemes the usage highlight and the definition highlight will both be applied, making the definition unreadable.

Check that the node is not the definition node before applying the usage highlight.